### PR TITLE
API Break;

### DIFF
--- a/src/Jack/Bounty/Main.php
+++ b/src/Jack/Bounty/Main.php
@@ -184,8 +184,8 @@ class Main extends PluginBase implements Listener{
 
     public function onDeath(PlayerDeathEvent $event){
         $cause = $event->getPlayer()->getLastDamageCause();
-        if ($cause->getDamager() instanceof Player) {
-            $killer = $cause->getDamager();
+        if ($cause->getModifier() instanceof Player) {
+            $killer = $cause->getModifier();
             if(isset($this->data["bounty"][$event->getPlayer()->getName()])){
                 $killer->sendMessage("Nice one you got $".$this->data["bounty"][$event->getPlayer()->getName()]." for killing ".$event->getPlayer()->getName()." who had a bounty on his/her head !");
                 $this->eco->addMoney($killer->getName(), $this->data["bounty"][$event->getPlayer()->getName()]);

--- a/src/Jack/Bounty/Main.php
+++ b/src/Jack/Bounty/Main.php
@@ -183,9 +183,10 @@ class Main extends PluginBase implements Listener{
 	}
 
     public function onDeath(PlayerDeathEvent $event){
-        $cause = $event->getPlayer()->getLastDamageCause();
-        if ($cause->getModifier() instanceof Player) {
-            $killer = $cause->getModifier();
+       $ent = $event->getEntity();
+	$cause = $ent->getLastDamageCause();
+        if ($cause instanceof Player) {
+            $killer = $cause->getDamager();
             if(isset($this->data["bounty"][$event->getPlayer()->getName()])){
                 $killer->sendMessage("Nice one you got $".$this->data["bounty"][$event->getPlayer()->getName()]." for killing ".$event->getPlayer()->getName()." who had a bounty on his/her head !");
                 $this->eco->addMoney($killer->getName(), $this->data["bounty"][$event->getPlayer()->getName()]);


### PR DESCRIPTION
Hi. This issue should fix: the rename from getDamager() to getModifier(). This was a API break that pocketmine have done over the past few weeks or months, and I just thought I'd update it to that API, and make sure to update all the plugin's problems and issues I see.
This has not been tested yet however, you may want to test this commit before merging.
If more errors occur, please let me know, and I'll do more testing myself to double check that this issue get's resolved.
## UPDATES ##
The updates which consists:
Updating the propertie's code (onDeath) event, to double check that getModifier is now involved and added, instead of getDamager(), the pre-resistance bug which has occurred for a while, and should now be fixed.
This issue should also fix: #5 
If there's anything else I need to change, then please let me know.
Thank you.  